### PR TITLE
 Changed the permission of entrypoint.sh in client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -26,5 +26,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf.tmp
 COPY ./docker-start.sh /entrypoint.sh
 
 EXPOSE 80
+RUN chmod +x entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "nginx", "-g", "daemon off;" ]


### PR DESCRIPTION
 Changed the permission of the bash file by chmod +x entrypoint.sh in order to solve the  following permission issue

`Cannot start service frontend: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/entrypoint.sh": permission denied: unknown
`