### PR TITLE
fix: login button alignment fix and removed unwanted box-shadow onhover

### DIFF
--- a/client/src/components/NewNav.js
+++ b/client/src/components/NewNav.js
@@ -81,10 +81,18 @@ const NavWrapper = styled.div`
   nav a {
     color: white;
     transition: all 0.3s ease-in-out;
+    &:last-child {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   nav a:hover {
     box-shadow: 0 2px 0 white;
+    &:last-child {
+      box-shadow: none;
+    }
   }
 
   nav a.active {


### PR DESCRIPTION
#### What this pr do ?
- center align login button
- removed unwanted box-shodow on hover in login button

#### Screenshots
- before
<img width="581" alt="Screenshot 2022-05-11 at 12 54 50 PM" src="https://user-images.githubusercontent.com/37608689/167794170-9860048c-fd48-45bc-add6-d3718896c329.png">

- after
<img width="581" alt="Screenshot 2022-05-11 at 1 06 07 PM" src="https://user-images.githubusercontent.com/37608689/167794565-7b1994f8-3610-424a-b4f8-8f265aec2f84.png">
